### PR TITLE
MVP-3181: Fix the GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ The function returns an array containing the following elements:
 
 ```
 {
-  "type": "message",
-  "name": "MY_MESSAGE" // Name of the message
-  "content": [ 
+    "type": "message",
+    "name": "MY_MESSAGE" // Name of the message
+    "content": [ 
      // Contains messages, fields, enums, etc.
-  ]
+    ]
 }
 ```
 
@@ -275,7 +275,7 @@ turns into:
 1. Update the parsing rules in `proto.peg`
 2. In the console, run `npm run build`. This generates a new `parser.js` file with the parsing rules.
 
-### Make a new version of the package
+### Publish a new version of the package
 
 1. Increment the package version number before submitting a PR
-2. After the PR is submitted, run the "Publish" workflow in GitHub Actions
+2. After the PR is merged, the "Publish" workflow will automatically run to publish a new version of the package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@q4justice/q4j-proto-parse",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@q4justice/q4j-proto-parse",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
         "ow": "^0.28.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@q4justice/q4j-proto-parse",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Quest for Justice utility to parse a proto3 file, forked from lal12/proto-parse",
   "main": "./src/proto-parse.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Q4Justice/proto-parse.git"
+    "url": "git+https://github.com/Q4Justice/q4j-proto-parse.git"
   },
   "publishConfig": {
     "@q4justice:registry": "https://npm.pkg.github.com/"
@@ -25,9 +25,9 @@
   "author": "jcnguyen",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Q4Justice/proto-parse/issues"
+    "url": "https://github.com/Q4Justice/q4j-proto-parse/issues"
   },
-  "homepage": "https://github.com/Q4Justice/proto-parse#readme",
+  "homepage": "https://github.com/Q4Justice/q4j-proto-parse#readme",
   "dependencies": {
     "ow": "^0.28.1"
   },


### PR DESCRIPTION
Publishing a new version of the package was failing because I renamed the repo to `q4j-proto-parse` but forgot to update the URL.